### PR TITLE
fix tags not added to internal set

### DIFF
--- a/api-wrapper/src/main/java/com/di72nn/stuff/wallabag/apiwrapper/WallabagService.java
+++ b/api-wrapper/src/main/java/com/di72nn/stuff/wallabag/apiwrapper/WallabagService.java
@@ -101,7 +101,7 @@ public class WallabagService {
 			if(tagsLocal == null) {
 				this.tags = tagsLocal = new HashSet<>();
 			}
-			tags.addAll(tagsLocal);
+			this.tags.addAll(tags);
 		}
 
 	}


### PR DESCRIPTION
Hi,

this fixes a bug in AddArticleBuilder, the .tags(Collection) method did not add the tags to the correct internal collection